### PR TITLE
feat: split formatter start and end markers

### DIFF
--- a/format.go
+++ b/format.go
@@ -21,7 +21,9 @@ const (
 // Formatter represents a log message formatter.
 type Formatter interface {
 	WriteMessage(buf *bytes.Buffer, ts time.Time, lvl Level, msg string)
+	AppendBeginMarker(buf *bytes.Buffer)
 	AppendEndMarker(buf *bytes.Buffer)
+	AppendLineBreak(buf *bytes.Buffer)
 	AppendArrayStart(buf *bytes.Buffer)
 	AppendArraySep(buf *bytes.Buffer)
 	AppendArrayEnd(buf *bytes.Buffer)
@@ -44,7 +46,7 @@ func JSONFormat() Formatter {
 }
 
 func (j *json) WriteMessage(buf *bytes.Buffer, ts time.Time, lvl Level, msg string) {
-	buf.WriteString(`{"`)
+	buf.WriteString(`"`)
 	if !ts.IsZero() {
 		buf.WriteString(TimestampKey)
 		buf.WriteString(`":`)
@@ -60,8 +62,16 @@ func (j *json) WriteMessage(buf *bytes.Buffer, ts time.Time, lvl Level, msg stri
 	appendString(buf, msg, true)
 }
 
+func (j *json) AppendBeginMarker(buf *bytes.Buffer) {
+	buf.WriteString("{")
+}
+
 func (j *json) AppendEndMarker(buf *bytes.Buffer) {
-	buf.WriteString("}\n")
+	buf.WriteString("}")
+}
+
+func (j *json) AppendLineBreak(buf *bytes.Buffer) {
+	buf.WriteString("\n")
 }
 
 func (j *json) AppendArrayStart(buf *bytes.Buffer) {
@@ -158,7 +168,11 @@ func (l *logfmt) WriteMessage(buf *bytes.Buffer, ts time.Time, lvl Level, msg st
 	appendString(buf, msg, l.needsQuote(msg))
 }
 
-func (l *logfmt) AppendEndMarker(buf *bytes.Buffer) {
+func (l *logfmt) AppendBeginMarker(*bytes.Buffer) {}
+
+func (l *logfmt) AppendEndMarker(*bytes.Buffer) {}
+
+func (l *logfmt) AppendLineBreak(buf *bytes.Buffer) {
 	buf.WriteByte('\n')
 }
 
@@ -297,7 +311,11 @@ func (c *console) WriteMessage(buf *bytes.Buffer, ts time.Time, lvl Level, msg s
 	appendString(buf, msg, false)
 }
 
-func (c *console) AppendEndMarker(buf *bytes.Buffer) {
+func (c *console) AppendBeginMarker(*bytes.Buffer) {}
+
+func (c *console) AppendEndMarker(*bytes.Buffer) {}
+
+func (c *console) AppendLineBreak(buf *bytes.Buffer) {
 	buf.WriteByte('\n')
 }
 

--- a/format_test.go
+++ b/format_test.go
@@ -13,10 +13,12 @@ func TestJsonFormat(t *testing.T) {
 	fmtr := logger.JSONFormat()
 
 	buf := bytes.NewBuffer(512)
+	fmtr.AppendBeginMarker(buf)
 	fmtr.WriteMessage(buf, time.Unix(123, 0).UTC(), logger.Error, "some message")
 	fmtr.AppendKey(buf, "error")
 	fmtr.AppendString(buf, "some error")
 	fmtr.AppendEndMarker(buf)
+	fmtr.AppendLineBreak(buf)
 
 	want := `{"ts":123,"lvl":"eror","msg":"some message","error":"some error"}` + "\n"
 	assert.Equal(t, want, string(buf.Bytes()))
@@ -174,10 +176,12 @@ func TestLogfmtFormat(t *testing.T) {
 	fmtr := logger.LogfmtFormat()
 
 	buf := bytes.NewBuffer(512)
+	fmtr.AppendBeginMarker(buf)
 	fmtr.WriteMessage(buf, time.Unix(123, 0).UTC(), logger.Error, "some message")
 	fmtr.AppendKey(buf, "error")
 	fmtr.AppendString(buf, "some error")
 	fmtr.AppendEndMarker(buf)
+	fmtr.AppendLineBreak(buf)
 
 	want := `ts=123 lvl=eror msg="some message" error="some error"` + "\n"
 	assert.Equal(t, want, string(buf.Bytes()))
@@ -335,10 +339,12 @@ func TestConsoleFormat(t *testing.T) {
 	fmtr := logger.ConsoleFormat()
 
 	buf := bytes.NewBuffer(512)
+	fmtr.AppendBeginMarker(buf)
 	fmtr.WriteMessage(buf, time.Unix(123, 0).UTC(), logger.Error, "some message")
 	fmtr.AppendKey(buf, "error")
 	fmtr.AppendString(buf, "some error")
 	fmtr.AppendEndMarker(buf)
+	fmtr.AppendLineBreak(buf)
 
 	want := "\x1b[34m12:02AM\x1b[0m \x1b[31mEROR\x1b[0m some message \x1b[31merror=\x1b[0msome error\n"
 	assert.Equal(t, want, string(buf.Bytes()))

--- a/logger.go
+++ b/logger.go
@@ -224,6 +224,7 @@ func (l *Logger) write(msg string, lvl Level, ctx []Field) {
 		ts = l.timeFn()
 	}
 
+	e.fmtr.AppendBeginMarker(e.buf)
 	e.fmtr.WriteMessage(e.buf, ts, lvl, msg)
 	e.buf.Write(l.ctx)
 
@@ -232,6 +233,7 @@ func (l *Logger) write(msg string, lvl Level, ctx []Field) {
 	}
 
 	e.fmtr.AppendEndMarker(e.buf)
+	e.fmtr.AppendLineBreak(e.buf)
 
 	_, _ = l.w.Write(e.buf.Bytes())
 


### PR DESCRIPTION
## Goal of this PR

This splits the formatters beginning and ending markers off from message start and end.

<!--
Fixes #
-->

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
