### PR TITLE
feat: cleanup time and duration rendering

### DIFF
--- a/format.go
+++ b/format.go
@@ -117,14 +117,16 @@ func (j *json) AppendTime(buf *bytes.Buffer, t time.Time) {
 	case TimeFormatUnix:
 		buf.AppendInt(t.Unix())
 	default:
-		s := t.Format(TimeFormat)
-		appendString(buf, s, true)
+		buf.WriteByte('"')
+		buf.AppendTime(t, TimeFormat)
+		buf.WriteByte('"')
 	}
 }
 
 func (j *json) AppendDuration(buf *bytes.Buffer, d time.Duration) {
-	s := d.String()
-	appendString(buf, s, true)
+	buf.WriteByte('"')
+	buf.AppendDuration(d)
+	buf.WriteByte('"')
 }
 
 func (j *json) AppendInterface(buf *bytes.Buffer, v any) {
@@ -215,14 +217,12 @@ func (l *logfmt) AppendTime(buf *bytes.Buffer, t time.Time) {
 	case TimeFormatUnix:
 		buf.AppendInt(t.Unix())
 	default:
-		s := t.Format(TimeFormat)
-		appendString(buf, s, l.needsQuote(s))
+		buf.AppendTime(t, TimeFormat)
 	}
 }
 
 func (l *logfmt) AppendDuration(buf *bytes.Buffer, d time.Duration) {
-	s := d.String()
-	appendString(buf, s, l.needsQuote(s))
+	buf.AppendDuration(d)
 }
 
 func (l *logfmt) AppendInterface(buf *bytes.Buffer, v any) {
@@ -362,13 +362,11 @@ func (c *console) AppendFloat(buf *bytes.Buffer, f float64) {
 }
 
 func (c *console) AppendTime(buf *bytes.Buffer, t time.Time) {
-	s := t.Format(time.Kitchen)
-	appendString(buf, s, false)
+	buf.AppendTime(t, time.Kitchen)
 }
 
 func (c *console) AppendDuration(buf *bytes.Buffer, d time.Duration) {
-	s := d.String()
-	appendString(buf, s, false)
+	buf.AppendDuration(d)
 }
 
 func (c *console) AppendInterface(buf *bytes.Buffer, v any) {

--- a/internal/bytes/buffer.go
+++ b/internal/bytes/buffer.go
@@ -3,6 +3,7 @@ package bytes
 
 import (
 	"strconv"
+	"time"
 	"unicode/utf8"
 )
 
@@ -34,6 +35,16 @@ func (b *Buffer) AppendFloat(f float64, fmt byte, prec, bitSize int) {
 // AppendBool appends a bool to the underlying Buffer.
 func (b *Buffer) AppendBool(v bool) {
 	b.b = strconv.AppendBool(b.b, v)
+}
+
+// AppendTime appends a time in the given format to the underlying Buffer.
+func (b *Buffer) AppendTime(t time.Time, layout string) {
+	b.b = t.AppendFormat(b.b, layout)
+}
+
+// AppendDuration appends the duration as a string to the underlying Buffer.
+func (b *Buffer) AppendDuration(d time.Duration) {
+	b.b = append(b.b, d.String()...)
 }
 
 // WriteByte writes a single byte to the Buffer.

--- a/internal/bytes/buffer_internal_test.go
+++ b/internal/bytes/buffer_internal_test.go
@@ -2,6 +2,7 @@ package bytes
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -59,16 +60,26 @@ func TestBuffer(t *testing.T) {
 			fn:   func() { buf.AppendFloat(3.14, 'f', 3, 64) },
 			want: "3.140",
 		},
+		{
+			name: "AppendTime",
+			fn:   func() { buf.AppendTime(time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC), time.DateTime) },
+			want: "2026-01-02 15:04:05",
+		},
+		{
+			name: "AppendDuration",
+			fn:   func() { buf.AppendDuration(3*time.Hour + 2*time.Minute + time.Second) },
+			want: "3h2m1s",
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			buf.Reset()
 
-			tt.fn()
+			test.fn()
 
-			assert.Equal(t, len(tt.want), buf.Len())
-			assert.Equal(t, tt.want, string(buf.Bytes()))
+			assert.Equal(t, len(test.want), buf.Len())
+			assert.Equal(t, test.want, string(buf.Bytes()))
 		})
 	}
 }


### PR DESCRIPTION
## Goal of this PR

This cleans up the time and duration context.

<!--
Fixes #
-->

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
